### PR TITLE
feat(config): add support for new package managers and update types

### DIFF
--- a/default.json
+++ b/default.json
@@ -44,11 +44,14 @@
   "packageRules": [
     {
       "matchManagers": [
-        "dockerfile"
+        "dockerfile",
+        "kubernetes",
+        "pre-commit"
       ],
       "matchUpdateTypes": [
         "minor",
-        "patch"
+        "patch",
+        "digest"
       ],
       "automerge": true,
       "automergeType": "pr"


### PR DESCRIPTION
This commit updates the configuration to include support for 
the "kubernetes" and "pre-commit" package managers. It also 
adds "digest" to the list of match update types, enhancing 
dependency management capabilities.