### PR TITLE
feat(k8s): update ExternalSecret API version and add approvebot

### DIFF
--- a/k8s/approve-bot.yaml
+++ b/k8s/approve-bot.yaml
@@ -1,0 +1,113 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: approvebot
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: approvebot
+  name: approvebot
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: approvebot
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: approvebot
+    spec:
+      serviceAccountName: approvebot
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: "app.kubernetes.io/name"
+                      operator: In
+                      values:
+                        - approvebot
+                topologyKey: kubernetes.io/hostname
+      containers:
+        - name: approvebot
+          env:
+            #opzkit-renovate-approver
+            - name: RENOVATE_BOT_USER
+              value: 'opzkit-renovate[bot]'
+            - name: APP_ID
+              value: '1313148'
+            - name: NODE_ENV
+              value: 'production'
+            - name: PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: credentials
+                  key: 'approver.privatekey.base64'
+            - name: WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: credentials
+                  key: WEBHOOK_SECRET
+          resources:
+            requests:
+              cpu: 100m
+              memory: 10Mi
+            limits:
+              cpu: 500m
+              memory: 200Mi
+          imagePullPolicy: IfNotPresent
+          image: ghcr.io/renovatebot/renovate-approve-bot:main
+          ports:
+            - name: web
+              containerPort: 3000
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: approvebot
+spec:
+  ports:
+    - port: 80
+      name: web
+      protocol: TCP
+      targetPort: "web"
+  selector:
+    app.kubernetes.io/name: approvebot
+  type: NodePort
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    alb.ingress.kubernetes.io/group.name: default
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/backend-protocol: HTTP
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/healthcheck-path: '/' #  TODO
+    alb.ingress.kubernetes.io/load-balancer-attributes: access_logs.s3.enabled=true,access_logs.s3.bucket=929585105493-eu-west-1-k8s-alb-access-logs
+  name: approvebot
+spec:
+  ingressClassName: "alb"
+  rules:
+    - host: approvebot-opzkit.k8s.sparetimecoders.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: approvebot
+                port:
+                  name: "web"
+            pathType: ImplementationSpecific
+  tls:
+    - hosts:
+        - approvebot-opzkit.k8s.sparetimecoders.com

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: credentials


### PR DESCRIPTION
Updates the ExternalSecret API version from v1beta1 to v1 to align 
with the latest API standards. Adds a new ServiceAccount, Deployment, 
Service, and Ingress for the approvebot, enabling automated 
approvals via webhook and enhancing Kubernetes management. 
Configures necessary environment variables and resource limits for 
efficient operation.