### PR TITLE
chore: update CODEOWNERS to add opzkit-renovate-approver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @argoyle @peter-svensson
+* @argoyle @peter-svensson @opzkit-renovate-approver


### PR DESCRIPTION
Adds @opzkit-renovate-approver to the CODEOWNERS file for 
inclusion in code review requests, ensuring more comprehensive 
oversight and collaboration among maintainers.