### PR TITLE
chore: update CODEOWNERS to remove obsolete approver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @argoyle @peter-svensson @opzkit-renovate-approver
+* @argoyle @peter-svensson


### PR DESCRIPTION
Removes the `@opzkit-renovate-approver` from the CODEOWNERS 
file as this reviewer is no longer needed for code reviews. 
This streamlines the approval process and reflects the current 
team structure.