### PR TITLE
fix: remove unnecessary commitlint config file path

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -11,5 +11,3 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6
-        with:
-          configFile: "./.github/commitlint.config.mjs"


### PR DESCRIPTION
Clean up the commitlint GitHub Action by removing the
configuration file path. This simplifies the action and
relies on the default configuration.