### PR TITLE
refactor(docs): simplify README usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,11 @@ Contains shareable config [presets](https://docs.github.com/en/actions/using-wor
 and [re-usable](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
 Github workflow for [renovate](https://docs.github.com/en/actions/using-workflows/reusing-workflows).
 
-The [default.json](./default.json) file contains the shared presets and the
-[renovate.yaml](.github/workflows/renovate.yaml) contains the workflow.
+The [default.json](./default.json) file contains the shared presets.
 
 ## Usage
-In the repository to use the shared config create a `.git/workflows/renovate.yaml` with content
-like the one in this [repo](.github/workflows/renovate_local.yaml).
 
-Replace `uses: ./.github/workflows/renovate.yaml` with:
-`uses: opzkit/renovate-config/.github/workflows/renovate.yaml@main`
-
-Then add a `.github/renovate.json` file with the following content:
+Add a `.github/renovate.json` file with the following content:
 
 ```json
 {
@@ -24,7 +18,3 @@ Then add a `.github/renovate.json` file with the following content:
 
 ## Github/Organization setup
 Renovate Github app [setup](https://docs.renovatebot.com/modules/platform/github/#running-as-a-github-app)
-
-Organization level Github action secrets:
-* `RENOVATE_APP_ID`
-* `RENOVATE_PRIVATE_KEY`


### PR DESCRIPTION
Update the README to streamline instructions for using the 
shared Renovate configuration. Remove outdated details about 
workflow file placement and clarify the steps for adding 
the required JSON configuration. This enhances readability 
and ensures users have clear guidance on setup.