### PR TITLE
feat(pre-commit): add renovate config validator hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,8 @@ repos:
         language: docker_image
         entry: --tty bridgecrew/checkov:3.2.354 --config-file checkov.yaml
         pass_filenames: false
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 41.132.5
+    hooks:
+      - id: renovate-config-validator
+        args: [ --strict ]


### PR DESCRIPTION
Adds the renovate config validator hook to the pre-commit configuration. 
This ensures that the configuration files for Renovate are validated 
strictly, facilitating better maintenance and adherence to standards.