### PR TITLE
feat: add 3-day minimum release age

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,6 +12,7 @@
     "main"
   ],
   "rebaseWhen": "conflicted",
+  "minimumReleaseAge": "3 days",
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
## Summary
- Adds `minimumReleaseAge: "3 days"` to the shared Renovate config so all updates are held back until their releases are at least 3 days old, reducing exposure to regressions in freshly published versions.